### PR TITLE
Fix java.lang.VerifyError caused by jackson library versions inconsistency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,6 +23,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
+                        <Embed-Dependency>jackson-databind,jackson-core,jackson-annotations</Embed-Dependency>
                         <Import-Package>
                             com.day.cq.commons.jcr;version="[5.7,6]",
                             org.apache.sling.event.jobs;version="[1.4,2]",
@@ -154,6 +155,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>2.5.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -462,12 +462,6 @@
                 <scope>provided</scope>
             </dependency>
             <!--GC Specific-->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>2.5.1</version>
-                <scope>provided</scope>
-            </dependency>
 
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -130,21 +130,6 @@
                             <target>${install.dir}</target>
                         </embedded>
                         <embedded>
-                            <groupId>com.fasterxml.jackson.core</groupId>
-                            <artifactId>jackson-databind</artifactId>
-                            <target>${install.dir}</target>
-                        </embedded>
-                        <embedded>
-                            <groupId>com.fasterxml.jackson.core</groupId>
-                            <artifactId>jackson-core</artifactId>
-                            <target>${install.dir}</target>
-                        </embedded>
-                        <embedded>
-                            <groupId>com.fasterxml.jackson.core</groupId>
-                            <artifactId>jackson-annotations</artifactId>
-                            <target>${install.dir}</target>
-                        </embedded>
-                        <embedded>
                             <groupId>org.apache.httpcomponents</groupId>
                             <artifactId>httpcore-osgi</artifactId>
                             <target>${install.dir}</target>
@@ -243,10 +228,6 @@
             <artifactId>servlet-api</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient-osgi</artifactId>


### PR DESCRIPTION
If GatherContent imports some jackson packages e.g. com.fasterxml.jackson.databind with high version e.g 2.7.3 from customer bundle which exports those packages, but it do not export com.fasterxml.jackson.databind.type package - it will be taken from another bundle (which was embedded to GatherContent package) with different version (2.5.1 in our case) - and those versions does not work correctly together.
Solution - embed jackson jar to bundle and do not import and use other versions from felix.