### PR TITLE
Fix JSON response being parsed twice

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/gathercontent/components/content/mapping-export/clientlibs/js/main.js
+++ b/ui.apps/src/main/content/jcr_root/apps/gathercontent/components/content/mapping-export/clientlibs/js/main.js
@@ -218,15 +218,15 @@ $(function () {
                 url: path + ".gctemplates.mappingType-" + mappingType + ".projectId-" + projectId + ".json",
                 type: "GET",
                 cache: false,
+                dataType:'json',
                 beforeSend: function () {
                     $(targetSelect).prop('disabled', true);
                     $(spinnerTarget).addClass('grayout');
                     spinnerTarget.appendChild(spinner.el);
                 },
                 success: function (data) {
-                    var json = JSON.parse(data);
-                    if (json.gctemplates) {
-                        json.gctemplates.forEach(function (item, index) {
+                    if (data.ates) {
+                        data.gctemplates.forEach(function (item, index) {
                             optionsString += "<option value='" + item.value + "'>" + item.text + "</option>";
                         });
                     }

--- a/ui.apps/src/main/content/jcr_root/apps/gathercontent/components/content/mapping-export/clientlibs/js/main.js
+++ b/ui.apps/src/main/content/jcr_root/apps/gathercontent/components/content/mapping-export/clientlibs/js/main.js
@@ -225,7 +225,7 @@ $(function () {
                     spinnerTarget.appendChild(spinner.el);
                 },
                 success: function (data) {
-                    if (data.ates) {
+                    if (data.gctemplates) {
                         data.gctemplates.forEach(function (item, index) {
                             optionsString += "<option value='" + item.value + "'>" + item.text + "</option>";
                         });

--- a/ui.apps/src/main/content/jcr_root/apps/gathercontent/components/content/mapping/clientlibs/js/main.js
+++ b/ui.apps/src/main/content/jcr_root/apps/gathercontent/components/content/mapping/clientlibs/js/main.js
@@ -221,15 +221,15 @@ $(function () {
                 url: path + ".gctemplates.mappingType-" + mappingType + ".projectId-" + projectId + ".json",
                 type: "GET",
                 cache: false,
+                dataType:'json',
                 beforeSend: function () {
                     $(targetSelect).prop('disabled', true);
                     $(spinnerTarget).addClass('grayout');
                     spinnerTarget.appendChild(spinner.el);
                 },
                 success: function (data) {
-                    var json = JSON.parse(data);
-                    if (json.gctemplates) {
-                        json.gctemplates.forEach(function (item, index) {
+                    if (data.gctemplates) {
+                        data.gctemplates.forEach(function (item, index) {
                             optionsString += "<option value='" + item.value + "'>" + item.text + "</option>";
                         });
                     }


### PR DESCRIPTION
jQuery normally doesn't automatically JSON parse responses without `dataType:'json'` defined in the request. However, in AEM 6.3 for some reason, perhaps due to the response type being `application/json`, it _is_ automatically parsed, which means this code throws:
```
Uncaught SyntaxError: Unexpected token o in JSON at position 1
    at JSON.parse (<anonymous>)
    at Object.success (clientlibs.js:512)
    at fire (jquery.js:3232)
    at Object.fireWith [as resolveWith] (jquery.js:3362)
    at done (jquery.js:9840)
    at XMLHttpRequest.callback (jquery.js:10311)
```
as it is trying to `JSON.parse` an object (original response was parsed by jQuery already). 

The solution, since we know this is always JSON, is to explicitly define the type as `json` and then skip parsing the response data ourselves. jQuery will always convert it, and we don't have to worry about it being parsed twice.